### PR TITLE
Running app from "/" instead of "/dist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run dev
 ```
 
 ### Access the sample page
-https://localhost:8080/dist
+https://localhost:8080
 
 
 ---

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -8,5 +8,8 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'var',
     library: 'Lib'
+  },
+  devServer: {
+  	contentBase: path.join(__dirname, 'dist')
   }
 };


### PR DESCRIPTION
Edited README.md and webpack.config.js to serve frontend from '/' instead of '/dist'