### PR TITLE
Fix typo in variable name and clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ npm run dev
 https://localhost:8080
 
 
+By default recorded videos will be available in `server/files` directory.
+
 ---
 
 ## Server ENV Options

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ cd server && npm i
 cd app && npm i
 ```
 
+### Configure the server
+
+Change the announced IP in src/config.js to your local ip (config -> webRtcTransport -> listenIps)
+
 ### Start the server
 
 ```bash
-# Change the listen IP in src/config.js to your local ip (config -> webRtcTransport -> listenIps)
-# Create [files] directory in order for the files to be saved
 # The server uses FFmpeg as default
 cd server && node src/server
 

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -34,7 +34,7 @@ const getVideoCodecs = () => {
   let params = new URLSearchParams(location.search.slice(1));
   let videoCodec = params.get('videocodec')
   const codec = mediasoupConfig.router.mediaCodecs.find(c=>{
-    if (!videocodec)
+    if (!videoCodec)
       return undefined;
 
     return ~c.mimeType.toLowerCase().indexOf(videoCodec.toLowerCase())

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -53,14 +53,14 @@ module.exports = Object.freeze({
     ]
   },
   webRtcTransport: {
-    listenIps: [ { ip: '192.168.60.99', announcedIp: undefined } ],
+    listenIps: [ { ip: '0.0.0.0', announcedIp: undefined } ], // TODO: Change announcedIp to your external IP or domain name
     enableUdp: true,
     enableTcp: true,
     preferUdp: true,
     maxIncomingBitrate: 1500000
   },
   plainRtpTransport: {
-    listenIp: '127.0.0.1',
+    listenIp: { ip: '0.0.0.0', announcedIp: undefined }, // TODO: Change announcedIp to your external IP or domain name
     rtcpMux: true,
     comedia: false
   }


### PR DESCRIPTION
 1. Fix typo in variable name (or “Start record” button wasn't enabled otherwise)
 2. Clarify documentation about IP addresses (see https://github.com/ethand91/mediasoup3-record-demo/issues/21#issuecomment-668751513)
 3. Don't make user to create files directory by hand 