### PR TITLE
Fix compatibility with mediasoup-client >=3.6.45

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -102,6 +102,7 @@ const handleJsonMessage = async (jsonMessage) => {
 
 const handleCreateTransportRequest = async (jsonMessage) => {
   const transport = await createTransport('webRtc', router);
+  transport.dtlsParameters.role = 'client';
 
   const peer = peers.get(jsonMessage.sessionId);
   peer.addTransport(transport);


### PR DESCRIPTION
For context:
https://github.com/versatica/mediasoup-client/commit/325cea2dcd21456c862feae52521c2cf7f2e450b
and specifically
https://github.com/versatica/mediasoup-client/commit/b3902d859ff8533758913f4c3be9f7d2a8f7bd41

With this commit of mine, the backend sends `role=client` to the browser,
then the browser sends `role=server`
to the backend's handleTransportConnectRequest.

Without this commit, the backend sends `role=server`,
then the browser sends `role=client`.

Without this commit, the browser drops
the connection (ICE?) in 5000 ms in ~97% cases
(I don't know why it works in ~3% cases),
and not a single video/audioframe gets ever sent by the browser.
By "drops" I mean nothing happens for 5000 ms and then
`sendTransport.on('connectionstatechange')`
receives `disconnected`.